### PR TITLE
Revert adding nexus plugin

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -205,9 +205,6 @@
 
         <!-- Checkstyle -->
         <air.checkstyle.config-file>checkstyle/airbase-checks.xml</air.checkstyle.config-file>
-
-        <!-- nexus-staging-maven-plugin version -->
-        <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
     </properties>
 
     <build>
@@ -920,9 +917,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <preparationGoals>clean verify -DskipTests</preparationGoals>
-                </configuration>
             </plugin>
 
             <plugin>
@@ -987,17 +981,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>${dep.nexus-staging-plugin.version}</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,6 @@
 
     <inceptionYear>2013</inceptionYear>
 
-    <properties>
-        <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
-    </properties>
-
     <licenses>
         <license>
             <name>Apache License 2.0</name>
@@ -121,44 +117,17 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <preparationGoals>clean verify -DskipTests</preparationGoals>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>${dep.nexus-staging-plugin.version}</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 
     <profiles>
         <profile>
             <id>oss-release</id>
-            <properties>
-                <!-- tests run in the preparation step of the release -->
-                <skipTests>true</skipTests>
-            </properties>
             <build>
                 <plugins>
-                    <!-- oss requires a javadoc jar. Build one when releasing. -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
-                    <!-- Sign artifacts using gpg for oss upload -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
This reverts the following commits:

- "Add nexus plugin into airbase/pom.xml": 31004374a33082638a1942fbf03a9167c493eebc.
- "Fix nexus plugin for oss deployment": 86be5ef322ada551f786274fa5353a2b4c391781.
- "Prepare airbase for deploy to oss using nexus plugin": 03e6d0ed0e9d5bb40b259ed162a88f1679fe62f1.

The reason is any project use airbase as parent pom will enable the
nexus plugin for oss deployment, which in some case is undesired.