### PR TITLE
Exclude mozilla/public-suffix-list.txt from duplicate finder

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -627,6 +627,7 @@
                             <ignoredResourcePattern>plugin\.properties</ignoredResourcePattern>
                             <ignoredResourcePattern>.*\.java</ignoredResourcePattern>
                             <ignoredResourcePattern>THIRD-PARTY</ignoredResourcePattern>
+                            <ignoredResourcePattern>mozilla/public-suffix-list.txt</ignoredResourcePattern>
                         </ignoredResourcePatterns>
                         <ignoredClassPatterns>
                             <ignoredClassPattern>module-info</ignoredClassPattern>


### PR DESCRIPTION
It is not very critical to always have the latest and consistent list and hence
don't fail builds if multiple versions of this file found