### PR TITLE
Use jackson 2.9.10.5

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -181,7 +181,7 @@
         <dep.javax-validation.version>2.0.1.Final</dep.javax-validation.version>
         <dep.javax-servlet.version>3.1.0</dep.javax-servlet.version>
         <dep.bval.version>2.0.0</dep.bval.version>
-        <dep.jackson.version>2.9.8</dep.jackson.version>
+        <dep.jackson.version>2.9.10.5</dep.jackson.version>
         <dep.jmxutils.version>1.19</dep.jmxutils.version>
         <dep.cglib.version>3.2.5</dep.cglib.version>
         <dep.joda.version>2.9.9</dep.joda.version>


### PR DESCRIPTION
Currently the pom.xml relies on jackson 2.9.8 which has several CVEs

Ideally we would update to jackson 2.9.10.x

Here's some of the CVEs:

https://nvd.nist.gov/vuln/detail/CVE-2020-11112
https://nvd.nist.gov/vuln/detail/CVE-2020-11113
https://nvd.nist.gov/vuln/detail/CVE-2020-11619
https://nvd.nist.gov/vuln/detail/CVE-2020-11620
https://nvd.nist.gov/vuln/detail/CVE-2019-12086
https://nvd.nist.gov/vuln/detail/CVE-2019-12384
https://nvd.nist.gov/vuln/detail/CVE-2019-12814
https://nvd.nist.gov/vuln/detail/CVE-2019-14379
https://nvd.nist.gov/vuln/detail/CVE-2019-14439
https://nvd.nist.gov/vuln/detail/CVE-2019-14540
https://nvd.nist.gov/vuln/detail/CVE-2019-14893
https://nvd.nist.gov/vuln/detail/CVE-2019-14892
https://nvd.nist.gov/vuln/detail/CVE-2019-16335
https://nvd.nist.gov/vuln/detail/CVE-2019-16942
https://nvd.nist.gov/vuln/detail/CVE-2019-16943
https://nvd.nist.gov/vuln/detail/CVE-2019-17267
https://nvd.nist.gov/vuln/detail/CVE-2019-17531

And several more