### PR TITLE
Upgrade jackson version to 2.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 
 jdk:
-  - oraclejdk8
-  - oraclejdk9
+  - openjdk8
   - openjdk10
   - openjdk11
-  - openjdk-ea

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -181,7 +181,7 @@
         <dep.javax-validation.version>2.0.1.Final</dep.javax-validation.version>
         <dep.javax-servlet.version>3.1.0</dep.javax-servlet.version>
         <dep.bval.version>2.0.0</dep.bval.version>
-        <dep.jackson.version>2.9.10.5</dep.jackson.version>
+        <dep.jackson.version>2.10.0</dep.jackson.version>
         <dep.jmxutils.version>1.19</dep.jmxutils.version>
         <dep.cglib.version>3.2.5</dep.cglib.version>
         <dep.joda.version>2.9.9</dep.joda.version>


### PR DESCRIPTION
`2.9.10.5` version is not a valid version for jackson-annotations / jackson-core dependencies.
Upgrading to a correct version `2.10.0`
fixes the upgrade done in https://github.com/prestodb/airbase/pull/10