### PR TITLE
Update git-commit-id-plugin to 4.0.3

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -516,8 +516,14 @@
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
-                    <version>2.1.13</version>
+                    <version>4.0.3</version>
                     <configuration>
+                        <!-- Include only properties used above to speed up build (https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/462) -->
+                        <includeOnlyProperties>
+                            <includeOnlyProperty>\Qgit.build.time</includeOnlyProperty>
+                            <includeOnlyProperty>\Qgit.commit.id</includeOnlyProperty>
+                            <includeOnlyProperty>\Qgit.commit.id.describe</includeOnlyProperty>
+                        </includeOnlyProperties>
                         <dateFormat>yyyy-MM-dd'T'HH:mm:ssZZ</dateFormat>
                         <gitDescribe>
                             <tags>true</tags>


### PR DESCRIPTION
Older version of git-commit-id errors out with GH actions when it attempts to operate on the repo as GH actions checked it out