### PR TITLE
Upgrade jackson databind 2.10.0 -> 2.10.5.1

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -181,7 +181,8 @@
         <dep.javax-validation.version>2.0.1.Final</dep.javax-validation.version>
         <dep.javax-servlet.version>3.1.0</dep.javax-servlet.version>
         <dep.bval.version>2.0.0</dep.bval.version>
-        <dep.jackson.version>2.10.0</dep.jackson.version>
+        <dep.jackson.version>2.10.5</dep.jackson.version>
+        <dep.jackson.databind.version>2.10.5.1</dep.jackson.databind.version>
         <dep.jmxutils.version>1.19</dep.jmxutils.version>
         <dep.cglib.version>3.2.5</dep.cglib.version>
         <dep.joda.version>2.9.9</dep.joda.version>
@@ -1133,7 +1134,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${dep.jackson.version}</version>
+                <version>${dep.jackson.databind.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Jackson databind was flagged in [CVE-2020-25649](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-25649)

Other jackson libraries don't have the 2.10.5.1 release, so I created a new property.