### PR TITLE
Ignore Java 9 module files

### DIFF
--- a/airbase-policy/pom.xml
+++ b/airbase-policy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airbase-root</artifactId>
-        <version>103</version>
+        <version>104-SNAPSHOT</version>
     </parent>
 
     <artifactId>airbase-policy</artifactId>

--- a/airbase-policy/pom.xml
+++ b/airbase-policy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airbase-root</artifactId>
-        <version>103-SNAPSHOT</version>
+        <version>103</version>
     </parent>
 
     <artifactId>airbase-policy</artifactId>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.facebook.airlift</groupId>
     <artifactId>airbase</artifactId>
-    <version>103-SNAPSHOT</version>
+    <version>103</version>
     <packaging>pom</packaging>
 
     <name>airbase</name>
@@ -25,7 +25,7 @@
         <connection>scm:git:git@github.com/prestodb/airbase.git</connection>
         <developerConnection>scm:git:git@github.com:prestodb/airbase.git</developerConnection>
         <url>https://github.com/prestodb/airbase</url>
-        <tag>HEAD</tag>
+        <tag>103</tag>
     </scm>
 
     <developers>
@@ -725,7 +725,7 @@
                         <dependency>
                             <groupId>com.facebook.airlift</groupId>
                             <artifactId>airbase-policy</artifactId>
-                            <version>103-SNAPSHOT</version>
+                            <version>103</version>
                         </dependency>
                     </dependencies>
                     <configuration>
@@ -847,7 +847,7 @@
                         <dependency>
                             <groupId>com.facebook.airlift</groupId>
                             <artifactId>airbase-policy</artifactId>
-                            <version>103-SNAPSHOT</version>
+                            <version>103</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.facebook.airlift</groupId>
     <artifactId>airbase</artifactId>
-    <version>103</version>
+    <version>104-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>airbase</name>
@@ -25,7 +25,7 @@
         <connection>scm:git:git@github.com/prestodb/airbase.git</connection>
         <developerConnection>scm:git:git@github.com:prestodb/airbase.git</developerConnection>
         <url>https://github.com/prestodb/airbase</url>
-        <tag>103</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>
@@ -725,7 +725,7 @@
                         <dependency>
                             <groupId>com.facebook.airlift</groupId>
                             <artifactId>airbase-policy</artifactId>
-                            <version>103</version>
+                            <version>104-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                     <configuration>
@@ -847,7 +847,7 @@
                         <dependency>
                             <groupId>com.facebook.airlift</groupId>
                             <artifactId>airbase-policy</artifactId>
-                            <version>103</version>
+                            <version>104-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -637,6 +637,7 @@
                             <ignoredResourcePattern>mozilla/public-suffix-list.txt</ignoredResourcePattern>
                         </ignoredResourcePatterns>
                         <ignoredClassPatterns>
+                            <ignoredClassPattern>.*\.?module-info</ignoredClassPattern>
                             <ignoredClassPattern>module-info</ignoredClassPattern>
                         </ignoredClassPatterns>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.facebook.airlift</groupId>
     <artifactId>airbase-root</artifactId>
-    <version>103</version>
+    <version>104-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>airbase-root</name>
@@ -28,7 +28,7 @@
         <connection>scm:git:git@github.com/prestodb/airbase.git</connection>
         <developerConnection>scm:git:git@github.com:prestodb/airbase.git</developerConnection>
         <url>https://github.com/prestodb/airbase</url>
-        <tag>103</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.facebook.airlift</groupId>
     <artifactId>airbase-root</artifactId>
-    <version>103-SNAPSHOT</version>
+    <version>103</version>
     <packaging>pom</packaging>
 
     <name>airbase-root</name>
@@ -28,7 +28,7 @@
         <connection>scm:git:git@github.com/prestodb/airbase.git</connection>
         <developerConnection>scm:git:git@github.com:prestodb/airbase.git</developerConnection>
         <url>https://github.com/prestodb/airbase</url>
-        <tag>HEAD</tag>
+        <tag>103</tag>
     </scm>
 
     <developers>


### PR DESCRIPTION
Tested by building Presto without the necessary exclusions in https://github.com/prestodb/presto/pull/17308/files and didn't get the duplicate finder error.

Context is this is some module related file added by Java 9 and it causes a lot of conflicts that don't matter.