### PR TITLE
Upgrading maven deploy, clean, install, duplicate finder and mycila license plugins to resolve mutiple CVE's

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -238,19 +238,19 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
+                    <version>3.1.1</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.3.2</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>3.1.1</version>
                 </plugin>
 
                 <plugin>
@@ -552,7 +552,7 @@
                 <plugin>
                     <groupId>org.basepom.maven</groupId>
                     <artifactId>duplicate-finder-maven-plugin</artifactId>
-                    <version>1.2.1</version>
+                    <version>1.5.1</version>
                     <executions>
                         <execution>
                             <id>default</id>
@@ -717,7 +717,7 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>4.3</version>
                     <dependencies>
                         <!-- This version must match the Airbase version. It will be updated by -->
                         <!-- the Maven Release plugin. The "project.version" property cannot be -->


### PR DESCRIPTION
The older versions of maven deploy, clean, install, duplicate finder and mycila license plugins have multiple CVE's reported so upgrading them to version compatible with java 8 and resolving them.