### PR TITLE
Fix git-commit-id-plugin for shallow clones

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -528,6 +528,7 @@
                         <dateFormat>yyyy-MM-dd'T'HH:mm:ssZZ</dateFormat>
                         <gitDescribe>
                             <tags>true</tags>
+                            <always>true</always>
                         </gitDescribe>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
This should fix issue with git describe for the git-commit-id plugin where builds could fail with the error "Unable to find commits until some tag".

see: https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/61

Example failure: https://github.com/prestodb/airlift/actions/runs/8724074771/job/23934491095?pr=76