### PR TITLE
Add hook for altering surefire JVM argLine

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -110,6 +110,9 @@
         <!-- define the JVM size for forked tests. Defaults to build JVM size. -->
         <air.test.jvmsize>${air.build.jvmsize}</air.test.jvmsize>
 
+        <!-- provide additional options for test JVM -->
+        <air.test.jvm.additional-arguments></air.test.jvm.additional-arguments>
+
         <!-- Lint mode for Javadoc. Defaults to 'all'. -->
         <air.javadoc.lint>all</air.javadoc.lint>
 
@@ -436,6 +439,7 @@
                             -XX:+ExitOnOutOfMemoryError
                             -XX:+HeapDumpOnOutOfMemoryError
                             -XX:-OmitStackTraceInFastThrow
+                            ${air.test.jvm.additional-arguments}
                         </argLine>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
The change is needed to add `-Djdk.attach.allowAttachSelf=true` argument to `maven-surefire-plugin` in `prestodb/airlift` project to be able to build `jmx` module on Java 11.
See https://github.com/airlift/airlift/pull/840/files for the change needs to be done in `prestodb/airlift`.

Cherry-pick of https://github.com/airlift/airbase/pull/216/commits/f5f054e38273f3dee2c5590d68624765612db258
Co-authored-by: Piotr Findeisen <piotr.findeisen@gmail.com>

**Successful build** 
```shell
dnskr@DESKTOP-C71KJJ0 MINGW64 ~/IdeaProjects/airbase (additional-surefire-args)
$ export JAVA_HOME='C:\Users\dnskr\.jdks\temurin-1.8.0_382' && mvn verify -DskipTests
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] airbase-root                                                       [pom]
[INFO] airbase-policy                                                     [jar]
[INFO] airbase                                                            [pom]
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for airbase-root 104-SNAPSHOT:
[INFO]
[INFO] airbase-root ....................................... SUCCESS [  0.004 s]
[INFO] airbase-policy ..................................... SUCCESS [  0.821 s]
[INFO] airbase ............................................ SUCCESS [  3.560 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.665 s
[INFO] Finished at: 2024-04-26T00:22:31+02:00
[INFO] ------------------------------------------------------------------------
```