### PR TITLE
Downgrade guice to 6.0.0

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -176,7 +176,7 @@
         <dep.packaging.version>0.163</dep.packaging.version>
 
         <!-- Dependency versions that should be the same everywhere. -->
-        <dep.guice.version>7.0.0</dep.guice.version>
+        <dep.guice.version>6.0.0</dep.guice.version>
         <dep.guava.version>26.0-jre</dep.guava.version>
         <dep.slf4j.version>1.7.25</dep.slf4j.version>
         <dep.logback.version>1.2.3</dep.logback.version>
@@ -1108,6 +1108,13 @@
                 <groupId>javax.ws.rs</groupId>
                 <artifactId>javax.ws.rs-api</artifactId>
                 <version>2.1</version>
+            </dependency>
+
+            <!-- javax inject -->
+            <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>1</version>
             </dependency>
 
             <!-- jsr 250 -->


### PR DESCRIPTION
To make it easier to integrate with libraries that need to stay on java8.  Also add javax.inject dependency since guice 6.0.0 only supports toProvider(<T extends Provider>.class) with javax.inject.Provider and not jakarta.inject.Provider.

Tested building airlift with these changes and the guice and javax overrides removed.