### PR TITLE
Add name to pom.xml for airbase-policy

### DIFF
--- a/airbase-policy/pom.xml
+++ b/airbase-policy/pom.xml
@@ -10,5 +10,6 @@
 
     <artifactId>airbase-policy</artifactId>
 
+    <name>airbase-policy</name>
     <description>Policy files for Airbase</description>
 </project>


### PR DESCRIPTION
Fix the release error:

```
Deployment 54b644b5-d86c-4db6-924d-62d4b04af9ff failed
pkg:maven/com.facebook.airlift/airbase-policy@106:
 - Project name is missing
```