### PR TITLE
Upgrade logback to 1.3.15

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -138,7 +138,7 @@
         <dep.guice.version>6.0.0</dep.guice.version>
         <dep.guava.version>26.0-jre</dep.guava.version>
         <dep.slf4j.version>1.7.25</dep.slf4j.version>
-        <dep.logback.version>1.2.3</dep.logback.version>
+        <dep.logback.version>1.3.15</dep.logback.version>
         <dep.jakarta-inject.version>2.0.1</dep.jakarta-inject.version>
         <dep.jakarta-validation.version>3.0.2</dep.jakarta-validation.version>
         <dep.jakarta-servlet.version>6.1.0</dep.jakarta-servlet.version>


### PR DESCRIPTION
1.2.x is no longer maintained, and has CVEs flagged

1.5.x requires JDK 11+ at compile time which
we cannot do for a lot of Presto modules at the moment

More details at : https://logback.qos.ch/download.html