### PR TITLE
Use native git client for git-commit-id-plugin

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -475,6 +475,7 @@
                     <artifactId>git-commit-id-plugin</artifactId>
                     <version>4.0.3</version>
                     <configuration>
+                        <useNativeGit>true</useNativeGit>
                         <!-- Include only properties used above to speed up build (https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/462) -->
                         <includeOnlyProperties>
                             <includeOnlyProperty>\Qgit.build.time</includeOnlyProperty>


### PR DESCRIPTION
This is needed to support git worktrees in child repositories which use airbase.  For more details, see: https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/215#issuecomment-1427551194