### PR TITLE
chore(deps): Upgrade jol-core to latest

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <!-- see http://docs.codehaus.org/display/MAVENUSER/POM+Element+for+Source+File+Encoding -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.targetJdk>1.8</project.build.targetJdk>
+        <project.build.targetJdk>17</project.build.targetJdk>
         <project.report.outputEncoding>UTF-8</project.report.outputEncoding>
         <project.report.inputEncoding>UTF-8</project.report.inputEncoding>
 
@@ -76,7 +76,7 @@
         <air.javadoc.lint>all</air.javadoc.lint>
 
         <!-- Target Java version for Modernizer -->
-        <air.modernizer.java-version>${project.build.targetJdk}</air.modernizer.java-version>
+        <air.modernizer.java-version>1.8</air.modernizer.java-version>
 
         <!-- Controls all the checkers run when building the project.            -->
         <!-- Can be activated with -Dair.check.skip-all=true on the command line. -->
@@ -157,7 +157,7 @@
         <dep.hamcrest.version>1.3</dep.hamcrest.version>
         <dep.mockito.version>1.9.5</dep.mockito.version>
         <dep.objenesis.version>1.3</dep.objenesis.version>
-        <dep.slice.version>0.37</dep.slice.version>
+        <dep.slice.version>0.45</dep.slice.version>
         <dep.jmh.version>1.20</dep.jmh.version>
 
         <!-- license headers -->


### PR DESCRIPTION
## Description
To update jol-core some other elements need to be upgraded, particularly slice. Also upgraded target bytecode to be able to compile jol-core latest version, while keeping the modernizer version to 1.8 to avoid having to make many code-style changes.

Fixes:
 - https://github.com/prestodb/presto/issues/24005