### PR TITLE
chore(deps): Revert jol-core 0.17 update and checkstyle java 17

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <!-- see http://docs.codehaus.org/display/MAVENUSER/POM+Element+for+Source+File+Encoding -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.targetJdk>17</project.build.targetJdk>
+        <project.build.targetJdk>1.8</project.build.targetJdk>
         <project.report.outputEncoding>UTF-8</project.report.outputEncoding>
         <project.report.inputEncoding>UTF-8</project.report.inputEncoding>
 
@@ -76,7 +76,7 @@
         <air.javadoc.lint>all</air.javadoc.lint>
 
         <!-- Target Java version for Modernizer -->
-        <air.modernizer.java-version>1.8</air.modernizer.java-version>
+        <air.modernizer.java-version>${project.build.targetJdk}</air.modernizer.java-version>
 
         <!-- Controls all the checkers run when building the project.            -->
         <!-- Can be activated with -Dair.check.skip-all=true on the command line. -->
@@ -157,7 +157,7 @@
         <dep.hamcrest.version>1.3</dep.hamcrest.version>
         <dep.mockito.version>1.9.5</dep.mockito.version>
         <dep.objenesis.version>1.3</dep.objenesis.version>
-        <dep.slice.version>0.45</dep.slice.version>
+        <dep.slice.version>0.37</dep.slice.version>
         <dep.jmh.version>1.20</dep.jmh.version>
 
         <!-- license headers -->
@@ -792,12 +792,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.0.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>12.3.1</version>
+                            <version>8.16</version>
                         </dependency>
                         <!-- This version must match the Airbase version. It will be updated by -->
                         <!-- the Maven Release plugin. The "project.version" property cannot be -->


### PR DESCRIPTION
Reverting jol core and checkstyle update to java 17 due to breaking changes with old jdk compatibility: https://github.com/prestodb/presto/issues/27382