### PR TITLE
chore(deps): Upgrade jackson version to 2.18.6

### DIFF
--- a/airbase/pom.xml
+++ b/airbase/pom.xml
@@ -144,7 +144,7 @@
         <dep.jakarta-servlet.version>6.1.0</dep.jakarta-servlet.version>
         <dep.jakarta-annotation.version>2.1.1</dep.jakarta-annotation.version>
         <dep.bval.version>2.0.6</dep.bval.version>
-        <dep.jackson.version>2.10.0</dep.jackson.version>
+        <dep.jackson.version>2.18.6</dep.jackson.version>
         <dep.jmxutils.version>1.19</dep.jmxutils.version>
         <dep.cglib.version>3.3.0</dep.cglib.version>
         <dep.joda.version>2.9.9</dep.joda.version>


### PR DESCRIPTION
## Description
Upgrades Jackson dependency from 2.10.0 to 2.18.6 to address security vulnerability and improve compatibility with modern Java features.

## Motivation
- **Security**: Addresses [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq)
- **Compatibility**: Jackson 2.18.6 provides improved serialization handling
- **Ecosystem**: Aligns with the Jackson version used by dependent projects like Presto

## Changes
- Updated `dep.jackson.version` from `2.10.0` to `2.18.6` in `airbase/pom.xml`

## Testing
- Airbase builds successfully with Jackson 2.18.6

<img width="721" height="112" alt="image" src="https://github.com/user-attachments/assets/638dad57-9ff4-4c9b-b83f-82be8cb05fde" />


## Related PRs
- Presto PR: https://github.com/prestodb/presto/pull/27293